### PR TITLE
bugfix: use correct AudioSource for Android 6 and above

### DIFF
--- a/src/com/callrecorder/android/RecordService.java
+++ b/src/com/callrecorder/android/RecordService.java
@@ -198,7 +198,11 @@ public class RecordService extends Service {
 		recorder = new MediaRecorder();
 
 		try {
-			recorder.setAudioSource(MediaRecorder.AudioSource.VOICE_CALL);
+			int source = MediaRecorder.AudioSource.VOICE_CALL;
+			// For Marshmallow and above, VOICE_CALL doesn't work but MIC does:
+			// https://developer.android.com/reference/android/os/Build.VERSION_CODES.html#M
+			if(android.os.Build.VERSION.SDK_INT >= 23) source = MediaRecorder.AudioSource.MIC;
+			recorder.setAudioSource(source);
 			recorder.setOutputFormat(MediaRecorder.OutputFormat.THREE_GPP);
 			recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AMR_NB);
 			fileName = FileHelper.getFilename(phoneNumber);


### PR DESCRIPTION
On Android Marshmallow (6) and above, no recordings were possible and
no files would be created. Instead, we get an error message regarding
audio capture.

[This issue](https://github.com/riul88/call-recorder-for-android/issues/41), however, briefly describes the solution, which is basically this patch.

Now the calls seems to be recorded correclty (tested on Android
6.0.1).

Note that even though the source says just `MIC`, both voices in the
call are captured.